### PR TITLE
Fix broken crew portraits by limiting the maximum level gain.

### DIFF
--- a/source/Strategia/Effects/LevelBooster.cs
+++ b/source/Strategia/Effects/LevelBooster.cs
@@ -31,7 +31,7 @@ namespace Strategia
             string astronautStr = string.IsNullOrEmpty(trait) ? "astronauts" : (trait.ToLower() + "s");
 
             int level = Parent.GetLeveledListItem<int>(levels);
-            return "All " + genderStr + astronautStr + " perform as if they had " + level + " more level" + (level == 1 ? "" : "s") + " of experience.";
+            return "All " + genderStr + astronautStr + " perform as if they had " + level + " more level" + (level == 1 ? "" : "s") + " of experience, up to a maximum of 5.";
         }
 
         protected override void OnLoadFromConfig(ConfigNode node)
@@ -78,7 +78,10 @@ namespace Strategia
                     gender == null || p.gender == gender
                 ))
             {
-                pcm.experienceLevel = KerbalRoster.CalculateExperienceLevel(pcm.experience) + level;
+				// Crew portraits break down if they have to display more than five stars, complicating EVA immensely.
+				// To prevent this, we have to limit the total level to 5.
+				int newLevel = KerbalRoster.CalculateExperienceLevel (pcm.experience) + level;
+				pcm.experienceLevel = newLevel > 5 ? 5 : newLevel;
             }
 
             return;


### PR DESCRIPTION
So I've stumbled into a problem:

1. A vessel spawns, everything is ok.
2. Kerbal goes on EVA, everything is *still* ok.
3. Kerbal goes back in, and suddenly, kerbals go missing from the crew portrait gallery, either all of them or just some, intermittently.

For reference, here's what the log looks like:
```
[LOG 16:22:52.066] [FLIGHT GLOBALS]: Switching To Vessel Kerbin Shipyard ---------------------- 
[LOG 16:22:52.066] Detected switch from kerbalEVA (Dancas Kerman) (Vessel) to MKS.EL.OrbitalDock (Kerbin Shipyard) (Vessel). Request camera stabilization.
[LOG 16:22:52.066] [PlanetariumCamera]: Focus: Kerbin Shipyard
[LOG 16:22:52.078] [2/17/2018 4:22:52 PM [x] Science!]: <Trace> (ShipStateWindow) - MapObjectSelected
[LOG 16:22:52.078] [2/17/2018 4:22:52 PM [x] Science!]: <Trace> (ShipStateWindow) - Vessel
[LOG 16:22:52.079] Camera Mode: AUTO
[ERR 16:22:52.119] InternalCameraSwitch: cameraTransform 'Window1EyeTransform' is null

[ERR 16:22:52.119] InternalCameraSwitch: colliderTransform 'Window1FocusPoint' is null

[ERR 16:22:52.119] InternalCameraSwitch: cameraTransform 'Window2EyeTransform' is null

[ERR 16:22:52.120] InternalCameraSwitch: colliderTransform 'Window2FocusPoint' is null

[LOG 16:22:52.132] Strategia: VesselValueImprover.HandleVessel
[LOG 16:22:52.132] Strategia: VesselValueImprover.HandleVessel
[LOG 16:22:52.132] Strategia: VesselValueImprover.HandleVessel
[LOG 16:22:52.139] [OSE] - 29 inventories found on this vessel!
[LOG 16:22:52.139] [OSE] - Max volume is: 18000 liters
[LOG 16:22:52.142] [KerbNet Controller] Scanning Vessel [Kerbin Shipyard]... Found [1] KerbNet Parts
[LOG 16:22:52.149] IR: [ServoController] vessel MKS.EL.OrbitalDock (Kerbin Shipyard)
[LOG 16:22:52.149] IR: [ServoController] OnVesselChange finished successfully
[LOG 16:22:52.154] Fix camera focus while keeping its position
[LOG 16:22:52.154] [BetterBurnTime] Vessel changed to Kerbin Shipyard
[LOG 16:22:52.155] FF: EventObserver:: OnVesselChange Kerbin Shipyard
[LOG 16:22:52.155] 2/17/2018 4:22:52 PM,DeepFreeze,DeepFreezeEvents onVesselWillDestroy 909dd369-5dbd-4881-9a2c-b3f7be558bef
[LOG 16:22:52.155] HullCam: Cleanup
[LOG 16:22:52.155] HullCam: Removed, now 3
[LOG 16:22:52.156] 2/17/2018 4:22:52 PM,KerbalAlarmClock,Active Vessel changed - resetting inqueue flag
[EXC 16:22:52.169] IndexOutOfRangeException: Array index is out of range.
	KSP.UI.Screens.Flight.KerbalPortrait.Setup (.Kerbal kerbal, UnityEngine.RectTransform containerViewport)
	KSP.UI.Screens.Flight.KerbalPortraitGallery.SpawnPortrait (.Kerbal crewMember)
	KSP.UI.Screens.Flight.KerbalPortraitGallery.RegisterActiveCrew (.Kerbal crewMember)
	Kerbal.Start ()
[ERR 16:22:52.190] Cannot find an InternalModule of typename 'EngineIgnitorRPM'

[ERR 16:22:52.213] Cannot find an InternalModule of typename 'EngineIgnitorRPM'

[ERR 16:22:52.233] Cannot find an InternalModule of typename 'EngineIgnitorRPM'

[ERR 16:22:52.253] Cannot find an InternalModule of typename 'EngineIgnitorRPM'

[ERR 16:22:52.272] Cannot find an InternalModule of typename 'EngineIgnitorRPM'

[ERR 16:22:52.292] Cannot find an InternalModule of typename 'EngineIgnitorRPM'

[LOG 16:22:52.316] HullCam: Cleanup
[LOG 16:22:52.317] HullCam: OnDestroy
[LOG 16:22:52.317] HullCam: Cleanup
[LOG 16:22:52.318] [Dynamic Battery Storage]: Summary: 
 vessel MKS.EL.OrbitalDock (Kerbin Shipyard) (loaded state True)
- 17 stock power handlers
[LOG 16:22:52.318] IR: [ServoController] OnVesselUnloaded, v=Dancas Kerman
[LOG 16:22:52.691] 2/17/2018 4:22:52 PM,KerbalAlarmClock,Removing DrawGUI from PostRender Queue
[LOG 16:22:52.697] [Dynamic Battery Storage]: Summary: 
 vessel MKS.EL.OrbitalDock (Kerbin Shipyard) (loaded state True)
- 17 stock power handlers
[LOG 16:22:52.698] [MechJeb2] Focus changed! Forcing Kerbin Shipyard to save
[LOG 16:22:52.736] [MechJeb2] Loading Mechjeb Dev #781 Sarbian
[LOG 16:22:52.756] ScaleModList: listSize 1312 maxListSize 674
[LOG 16:22:52.811] [Part:MKS.EL.OrbitalDock (Kerbin Shipyard) (id=F1719584088)#Module:18] Item transfer | destination seat: 0
[LOG 16:22:52.870] ScaleModList: listSize 1312 maxListSize 674
[LOG 16:22:52.875] 2/17/2018 4:22:52 PM,KerbalAlarmClock,Vessel Change from 'No Vessel' to 'Kerbin Shipyard'
[LOG 16:22:52.889] 2/17/2018 4:22:52 PM,KerbalAlarmClock,Adding DrawGUI to PostRender Queue
[LOG 16:22:52.889] 2/17/2018 4:22:52 PM,KerbalAlarmClock,Skipping version check
[EXC 16:22:52.953] IndexOutOfRangeException: Array index is out of range.
	KSP.UI.Screens.Flight.KerbalPortrait.Setup (.Kerbal kerbal, UnityEngine.RectTransform containerViewport)
	KSP.UI.Screens.Flight.KerbalPortraitGallery.SpawnPortrait (.Kerbal crewMember)
	KSP.UI.Screens.Flight.KerbalPortraitGallery.SetActivePortraitsForVessel (.Vessel v)
	KSP.UI.Screens.Flight.KerbalPortraitGallery+. ()
	CallbackUtil+.MoveNext ()
	UnityEngine.SetupCoroutine.InvokeMoveNext (IEnumerator enumerator, IntPtr returnValueAddress)
[LOG 16:22:54.659] FF: orbit closed detected for vessel MKS.EL.OrbitalDock (Kerbin Shipyard)
```

It took me most of a day to track down what's wrong, because, as you can see, I have a heavily modded setup, and mods update often -- I was associating the sudden breakage with an update, and thought one of the crew-related mods was to blame. Then, one of the graphics mods. Eventually I ruled everything out, but finally, I have stumbled on the solution: I have adopted the Engineer Focus III strategy since, and had multiple 4-star engineers. The vessels exhibiting the problem were the ones they were on.

I did not go that deep into the code to find out why this doesn't happen when the vessel initially spawns -- maybe, the LevelBooster doesn't get triggered at all, or maybe, because it gets triggered after the `KerbalPortraitGallery` has already done its job, I'm not sure -- but once the kerbal *boards*, the gallery is rebuilt and `KerbalPortrait` attempts to display more stars than five. That's when it dies, since there are only sprites for five.

Limiting the level boost so that the levels cannot be boosted beyond five fixes the problem. This might not be the best way to do it -- everything else works fine with more than five levels, so it would be preferable to cheat somehow and duck the level under five before `KerbalPortrait` runs and bring it back up after -- but it works.