### PR TITLE
Bug Fix 

### DIFF
--- a/source/Strategia/Effects/VesselValueImprover.cs
+++ b/source/Strategia/Effects/VesselValueImprover.cs
@@ -186,24 +186,24 @@ namespace Strategia
                             ModuleParachute parachute = m as ModuleParachute;
                             if (parachute != null)
                             {
-                                SetValue(p.partName, needsIncrease, ref parachute.fullyDeployedDrag);
+                                SetValue(p.persistentId.ToString(), needsIncrease, ref parachute.fullyDeployedDrag);
                             }
                             break;
                         case Attribute.StrutStrength:
                             CModuleStrut strut = m as CModuleStrut;
                             if (strut != null)
                             {
-                                SetValue(p.partName + "_linear", needsIncrease, ref strut.linearStrength);
-                                SetValue(p.partName + "_angular", needsIncrease, ref strut.angularStrength);
+                                SetValue(p.persistentId.ToString() + "_linear", needsIncrease, ref strut.linearStrength);
+                                SetValue(p.persistentId.ToString() + "_angular", needsIncrease, ref strut.angularStrength);
                             }
                             break;
                         case Attribute.ReactionWheelTorque:
                             ModuleReactionWheel reactionWheel = m as ModuleReactionWheel;
                             if (reactionWheel != null)
                             {
-                                SetValue(p.partName + "_pitch", needsIncrease, ref reactionWheel.PitchTorque);
-                                SetValue(p.partName + "_yaw", needsIncrease, ref reactionWheel.YawTorque);
-                                SetValue(p.partName + "_roll", needsIncrease, ref reactionWheel.RollTorque);
+                                SetValue(p.persistentId.ToString() + "_pitch", needsIncrease, ref reactionWheel.PitchTorque);
+                                SetValue(p.persistentId.ToString() + "_yaw", needsIncrease, ref reactionWheel.YawTorque);
+                                SetValue(p.persistentId.ToString() + "_roll", needsIncrease, ref reactionWheel.RollTorque);
                             }
                             break;
                     }
@@ -222,6 +222,7 @@ namespace Strategia
                 originalValues[name] = value;
             }
             value = originalValues[name] * (increaseRequired ? multiplier : 1.0f);
+            Debug.Log("Strategia.VesselValueImprover.SetValue]: " + name + ":" + originalValues[name].ToString() + " x " + (increaseRequired ? multiplier : 1.0f).ToString() + " = " + value.ToString() );
         }
     }
 }


### PR DESCRIPTION
The code as written tried to build a list of existing parts, but the key for the list was not unique across different parts of similar types. The fix uses the part's persistentID instead of partname, which should be unique.

What would happen is the first part would set the value of all subsequent parts in the same vessel, i.e. all reaction wheels got the same value. Not a big deal if it's a big reaction wheel. But if the first reaction wheel is a small probe core, then it nerfs the reaction wheels of the entire vessel. Also added a debug message to check the values were calculated correctly.